### PR TITLE
Fix the VARMA likelihood function for cases when p or q = 0.

### DIFF
--- a/R/LLKvarma.R
+++ b/R/LLKvarma.R
@@ -18,9 +18,8 @@ LLKvarma <- function(par, zt, p, q, include.mean, fixed) {
     ist <- 1
     beta <- rbind(beta, Ph0)
   }
-  PH <- NULL
+  PH <- matrix(0, kp, k)
   if (p > 0) {
-    PH <- matrix(0, kp, k)
     for (j in 1:k) {
       idx <- seq_len(kp)[fixed[(ist + 1):(ist + kp), j] == 1]
       jdx <- length(idx)
@@ -32,9 +31,8 @@ LLKvarma <- function(par, zt, p, q, include.mean, fixed) {
     ist <- ist + kp
     beta <- rbind(beta, PH)
   }
-  TH <- NULL
+  TH <- matrix(0, kq, k)
   if (q > 0) {
-    TH <- matrix(0, kq, k)
     for (j in 1:k) {
       idx <- c(1:kq)[fixed[(ist + 1):(ist + kq), j] == 1]
       jdx <- length(idx)


### PR DESCRIPTION
I tried to use the ``mlmts`` function ``dis_var_1`` and saw that the error was that we set matrices to be NULL when ``p`` or ``q`` was zero. This caused an error when passing them to the C++ function as it only accepted a matrix and not NULL. It now creates empty matrices when this happens, remedying the problem.