### PR TITLE
Modify the last row to avoid copying a dereferenced part of a matrix in the varmaResiduals function.

### DIFF
--- a/src/varmaResiduals.cpp
+++ b/src/varmaResiduals.cpp
@@ -61,6 +61,5 @@ Eigen::MatrixXd varmaResiduals(const Eigen::Map<Eigen::MatrixXd> &zt,
         Eigen::VectorXd tmp3 = zt.row(t) - tmp.transpose();
         at.row(t) = tmp3.transpose();
     }
-    at = at.bottomRows(nT-pqmax);
-    return at;
+    return at.bottomRows(nT-pqmax);
 }


### PR DESCRIPTION
Should fix the issue where asan complains when submitting to CRAN.